### PR TITLE
added some type-safety to the codegen value system. instead of passing the raw pointers of the virtual memory structs directly, their aliases in the value map are passed. this prevents remapping a value from causing dangling pointers to be passed around.

### DIFF
--- a/examples/fibonacci.ir
+++ b/examples/fibonacci.ir
@@ -4,21 +4,16 @@ define fn i32 main()
 end
 
 define fn i32 fib(i32 %n)
-    %ptr 1 = allocate 4
-    store 4 %n, %ptr 1
-    %2 = load 4 %ptr 1
-    %3 = icmp ule %2, 1
+    %3 = icmp ule %n, 1
     branch base_case recursive_case %3
 .base_case:
-    %4 = load 4 %ptr 1
-    ret %4
+    ret %n
 .recursive_case:
-    %5 = load 4 %ptr 1
-    %6 = sub %5, 1
+    %6 = sub %n, 1
     %7 = call fib %6
-    %8 = load 4 %ptr 1
-    %9 = sub %8, 2
+    %9 = sub %n, 2
     %10 = call fib %9
     %11 = add %10, %7
     ret %11
+
 end

--- a/src/backend/codegen/codegen.cpp
+++ b/src/backend/codegen/codegen.cpp
@@ -141,24 +141,28 @@ void backend::codegen::gen_function(std::ostream &ostream, const ir::global::fun
 }
 
 backend::codegen::instruction_return backend::codegen::gen_instruction(backend::codegen::function_context &context, const ir::block::block_instruction &instruction) {
-    std::vector<literal> literals;
-    std::vector<const vptr*> operands;
+    std::vector<std::string> operands;
 
     for (const auto& operand : instruction.operands) {
         if (std::holds_alternative<ir::int_literal>(operand.val)) {
             const auto &literal = std::get<ir::int_literal>(operand.val);
 
-            literals.emplace_back(
-            std::to_string(literal.value)
+            context.value_map.emplace(
+                std::to_string(literal.value),
+                std::make_unique<backend::codegen::literal>(std::to_string(literal.value))
             );
 
-            operands.push_back(&literals.back());
+            operands.emplace_back(
+                std::to_string(literal.value)
+            );
         } else if (std::holds_alternative<ir::variable>(operand.val)) {
             const auto &variable = std::get<ir::variable>(operand.val);
 
             debug::assert(context.value_map.contains(variable.name), "Variable not found in value map");
 
-            operands.push_back(context.value_map.at(variable.name).get());
+            operands.emplace_back(
+                variable.name
+            );
         }
     }
 

--- a/src/backend/codegen/codegen.hpp
+++ b/src/backend/codegen/codegen.hpp
@@ -25,6 +25,8 @@ namespace backend::codegen {
     struct instruction_return;
     struct vptr;
 
+    using vptr_gen = const vptr*(*)();
+
     struct function_context {
         std::ostream& ostream;
 
@@ -59,6 +61,24 @@ namespace backend::codegen {
             set_used(value.get(), true);
             value_map[name] = std::move(value);
             set_used(value.get(), false);
+        }
+
+        bool has_value(std::string_view name) const {
+            return value_map.contains(std::string { name });
+        }
+
+        vptr* get_value(std::string_view name) const {
+            return value_map.at(std::string { name }).get();
+        }
+
+        void unmap_to_temp(const char* name) {
+            auto temp = std::move(value_map.at(name));
+            value_map.erase(name);
+            value_map["__int__temp"] = std::move(temp);
+        }
+
+        void override_temp(virtual_pointer ptr) {
+           value_map["__int__temp"] = std::move(ptr);
         }
     };
 

--- a/src/backend/codegen/dataflow.cpp
+++ b/src/backend/codegen/dataflow.cpp
@@ -4,85 +4,56 @@
 
 void backend::codegen::empty_value(backend::codegen::function_context &context, const char *value) {
     auto &vmem = context.value_map.at(value);
+    auto mem_size = vmem->get_size();
 
-    if (vmem->get_size() > 8)
+    if (mem_size > 8)
         throw std::runtime_error("Cannot empty a pointer larger than 8 bytes");
 
-    auto new_memory = backend::codegen::find_memory(context, vmem->get_size());
+    auto new_memory = backend::codegen::find_memory(context, mem_size);
 
-    backend::codegen::emit_move(context, new_memory.get(), vmem.get(), 8);
-
-    context.remap_value(value, std::move(new_memory));
+    context.unmap_to_temp(value);
+    context.map_value(value, std::move(new_memory));
+    backend::codegen::emit_move(context, "temp", value, mem_size);
 }
 
-const backend::codegen::vptr* backend::codegen::move_to_register(backend::codegen::function_context &context,
-                                                                  const backend::codegen::vptr *vmem,
-                                                                  backend::codegen::register_t reg) {
+void backend::codegen::move_to_register(backend::codegen::function_context &context,
+                                        std::string_view value,
+                                        backend::codegen::register_t reg) {
     if (context.used_register[reg]) {
+        const auto *vmem = context.get_value(value);
         const auto *reg_storage = dynamic_cast<const backend::codegen::register_storage*>(vmem);
 
-        if (reg_storage && reg_storage->reg == reg) {
-            return vmem;
-        }
+        if (reg_storage && reg_storage->reg == reg)
+            return;
 
         backend::codegen::empty_register(context, reg);
     }
 
+    if (!context.has_value(value))
+        throw std::runtime_error("Value not found");
+
+
     auto new_memory = std::make_unique<backend::codegen::register_storage>(reg);
 
-    for (auto &[name, vptr] : context.value_map) {
-        if (vmem != vptr.get()) continue;
-
-        backend::codegen::emit_move(context, new_memory.get(), vmem, 8);
-        context.remap_value(name.c_str(), std::move(new_memory));
-        break;
-    }
-
-    auto *literal = dynamic_cast<const backend::codegen::literal*>(vmem);
-
-    if (!literal)
-        throw std::runtime_error("Unknown value!");
-
-    backend::codegen::emit_move(context, new_memory.get(), literal, 8);
-    return nullptr;
-}
-
-void backend::codegen::move_from_register(backend::codegen::function_context &context,
-                                          backend::codegen::register_t reg,
-                                          const backend::codegen::vptr *vmem) {
-    context.ostream << "    mov     " << vmem->get_address(vmem->get_size()) << ", " << backend::codegen::register_as_string(reg, vmem->get_size()) << '\n';
+    backend::codegen::emit_move(context, new_memory.get(), value, 8);
+    context.remap_value(value.data(), std::move(new_memory));
 }
 
 const backend::codegen::vptr* backend::codegen::empty_register(backend::codegen::function_context &context, backend::codegen::register_t reg) {
+
     for (auto &[name, vmem] : context.value_map) {
         auto *reg_storage = dynamic_cast<backend::codegen::register_storage*>(vmem.get());
 
         if (!reg_storage || reg_storage->reg != reg) continue;
 
         auto new_memory = backend::codegen::find_memory(context, vmem->get_size());
-        backend::codegen::emit_move(context, new_memory.get(), vmem.get(), 8);
+        backend::codegen::emit_move(context, new_memory.get(), name, 8);
 
         context.remap_value(name.c_str(), std::move(new_memory));
         return context.value_map.at(name).get();
     }
 
     return nullptr;
-}
-
-backend::codegen::virtual_pointer backend::codegen::pop_register(backend::codegen::function_context &context,
-                                                                 backend::codegen::register_t reg) {
-    for (auto &[name, vmem] : context.value_map) {
-        auto *reg_storage = dynamic_cast<backend::codegen::register_storage*>(vmem.get());
-
-        if (!reg_storage || reg_storage->reg != reg) continue;
-
-        auto new_memory = backend::codegen::find_memory(context, vmem->get_size());
-        backend::codegen::emit_move(context, new_memory.get(), vmem.get(), 8);
-
-        return new_memory;
-    }
-
-    throw std::runtime_error("No value in register");
 }
 
 backend::codegen::virtual_pointer backend::codegen::find_memory(backend::codegen::function_context &context, size_t size) {

--- a/src/backend/codegen/dataflow.hpp
+++ b/src/backend/codegen/dataflow.hpp
@@ -7,12 +7,9 @@ namespace backend::codegen {
     enum register_t : uint8_t;
 
     void empty_value(backend::codegen::function_context &context, const char* value);
-    const vptr *
-    move_to_register(backend::codegen::function_context &context, const backend::codegen::vptr *vmem, backend::codegen::register_t reg);
-    void move_from_register(backend::codegen::function_context &context, backend::codegen::register_t reg, const backend::codegen::vptr *vmem);
+    void move_to_register(backend::codegen::function_context &context, std::string_view value, backend::codegen::register_t reg);
 
     const vptr* empty_register(backend::codegen::function_context &context, backend::codegen::register_t reg);
-    virtual_pointer pop_register(backend::codegen::function_context &context, register_t reg);
 
     backend::codegen::virtual_pointer find_memory(backend::codegen::function_context &context, size_t size);
 }

--- a/src/backend/codegen/inst_output.cpp
+++ b/src/backend/codegen/inst_output.cpp
@@ -1,8 +1,21 @@
 #include "inst_output.hpp"
 #include "codegen.hpp"
 
-void backend::codegen::emit_move(function_context &context, const backend::codegen::vptr *dest,
-                                 const backend::codegen::vptr *src, size_t size) {
+void backend::codegen::emit_move(function_context &context,
+                                 const std::string_view dest_name,
+                                 const std::string_view src_name,
+                                 const size_t size) {
+    const auto *dest = context.get_value(dest_name);
+
+    emit_move(context, dest, src_name, size);
+}
+
+void backend::codegen::emit_move(function_context &context,
+                                 const vptr *dest,
+                                 const std::string_view src_name,
+                                 size_t size) {
+    const auto *src = context.get_value(src_name);
+
     const auto *dest_stack = dynamic_cast<const backend::codegen::stack_pointer*>(dest);
     const auto *src_stack = dynamic_cast<const backend::codegen::stack_pointer*>(src);
 

--- a/src/backend/codegen/inst_output.hpp
+++ b/src/backend/codegen/inst_output.hpp
@@ -3,6 +3,13 @@
 #include "codegen.hpp"
 
 namespace backend::codegen {
-    void emit_move(function_context &context, const backend::codegen::vptr *dest,
-                   const backend::codegen::vptr *src, size_t size);
+    void emit_move(function_context &context,
+              std::string_view dest,
+              std::string_view src,
+              size_t size);
+
+    void emit_move(function_context &context,
+               const vptr* dest,
+               std::string_view src,
+               size_t size);
 }

--- a/src/backend/codegen/instructions.hpp
+++ b/src/backend/codegen/instructions.hpp
@@ -13,6 +13,8 @@ namespace ir::block {
 namespace backend::codegen {
     struct function_context;
 
+    using v_operands = std::vector<std::string>;
+
     struct instruction_return {
         std::unique_ptr<vptr> return_dest;
         bool valid = true;
@@ -21,41 +23,41 @@ namespace backend::codegen {
     instruction_return gen_allocate(
             backend::codegen::function_context &context,
             const ir::block::allocate &allocate,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
     instruction_return gen_store(
             backend::codegen::function_context &context,
             const ir::block::store &store,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
     instruction_return gen_load(
             backend::codegen::function_context &context,
             const ir::block::load &load,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
     instruction_return gen_icmp(
             backend::codegen::function_context &context,
             const ir::block::icmp &icmp,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
     instruction_return gen_branch(
             backend::codegen::function_context &context,
             const ir::block::branch &branch,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
     instruction_return gen_return(
             backend::codegen::function_context &context,
             const ir::block::ret &ret,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
     instruction_return gen_arithmetic(
             backend::codegen::function_context &context,
             const ir::block::arithmetic &arithmetic,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
     instruction_return gen_call(
             backend::codegen::function_context &context,
             const ir::block::call &call,
-            std::vector<const vptr*> &virtual_operands
+            const v_operands &virtual_operands
     );
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -66,7 +66,7 @@ void hello_world_lex() {
     ir::output::instruction_emitter_attachment = backend::output::attach_variable_drop;
 //    ir::output::emit(std::cout, parsed);
 
-    backend::codegen::generate(parsed,  ofile);
+    backend::codegen::generate(parsed,  std::cout);
 
     asm("nop");
 }


### PR DESCRIPTION
additionally the fibonacci.ir example has been optimized a bit to not use a stack allocation with the n parameter, as this is what flared up the type-safety issue in the first place